### PR TITLE
Fix off by one error in wrap function

### DIFF
--- a/src/matcher.coffee
+++ b/src/matcher.coffee
@@ -87,7 +87,7 @@ exports.wrap = (string, query, options) ->
       strPos = matchPos
 
   #Get string after last match
-  if(strPos < string.length - 1)
+  if(strPos <= string.length - 1)
     output += string.substring(strPos)
 
   #return wrapped text


### PR DESCRIPTION
e.g. if you call `wrap("abcd", "bc")`, then the result will return `a<strong class=\"highlight\">bc</strong>`, missing the "d".